### PR TITLE
THRIFT-5921 Ubuntu focal fail to run composer install

### DIFF
--- a/build/docker/ubuntu-focal/Dockerfile
+++ b/build/docker/ubuntu-focal/Dockerfile
@@ -251,8 +251,11 @@ RUN apt-get install -y --no-install-recommends \
       php7.4-curl \
       php7.4-xdebug \
       php-pear \
-      re2c \
-      composer
+      re2c
+
+# Install Composer 2 explicitly to avoid distro package version drift.
+RUN curl -sS https://getcomposer.org/installer | php -- --2 --install-dir=/usr/local/bin --filename=composer && \
+    composer --version
 
 RUN apt-get install -y --no-install-recommends \
       `# Python3 dependencies` \


### PR DESCRIPTION

https://issues.apache.org/jira/browse/THRIFT-5921

In Ubuntu 20.04 default version of composer is 1.0 but from September 2025 it doe s not work. So For correct work of php tests composer 2.0 should be intstalled manualy

https://blog.packagist.com/packagist-org-shutdown-of-composer-1-x-support-postponed-to-september-1st-2025/
  

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [X] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [X] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [X] Did you squash your changes to a single commit?  (not required, but preferred)
- [X] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.
