### PR TITLE
THRIFT-5587: Add UUID support for PHP

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_php_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_php_generator.cc
@@ -671,6 +671,9 @@ string t_php_generator::render_const_value(t_type* type, t_const_value* value) {
         out << value->get_double();
       }
       break;
+    case t_base_type::TYPE_UUID:
+      out << '"' << get_escaped_string(value) << '"';
+      break;
     default:
       throw "compiler error: no const of base type " + t_base_type::t_base_name(tbase);
     }
@@ -2175,6 +2178,15 @@ void t_php_generator::generate_deserialize_field(ostream& out,
             out << indent() << "$arr = unpack('d', strrev(" << itrans << "->readAll(8)));" << '\n'
                 << indent() << "$" << name << " = $arr[1];" << '\n';
             break;
+          case t_base_type::TYPE_UUID:
+            out << indent() << "$_uuid_bin = " << itrans << "->readAll(16);" << '\n'
+                << indent() << "$_uuid_hex = bin2hex($_uuid_bin);" << '\n'
+                << indent() << "$" << name << " = substr($_uuid_hex, 0, 8) . '-' . "
+                << "substr($_uuid_hex, 8, 4) . '-' . "
+                << "substr($_uuid_hex, 12, 4) . '-' . "
+                << "substr($_uuid_hex, 16, 4) . '-' . "
+                << "substr($_uuid_hex, 20, 12);" << '\n';
+            break;
           default:
             throw "compiler error: no PHP name for base type " + t_base_type::t_base_name(tbase)
                 + tfield->get_name();
@@ -2215,6 +2227,9 @@ void t_php_generator::generate_deserialize_field(ostream& out,
             break;
           case t_base_type::TYPE_DOUBLE:
             out << "readDouble($" << name << ");";
+            break;
+          case t_base_type::TYPE_UUID:
+            out << "readUuid($" << name << ");";
             break;
           default:
             throw "compiler error: no PHP name for base type " + t_base_type::t_base_name(tbase);
@@ -2417,6 +2432,9 @@ void t_php_generator::generate_serialize_field(ostream& out, t_field* tfield, st
         case t_base_type::TYPE_DOUBLE:
           out << indent() << "$output .= strrev(pack('d', $" << name << "));" << '\n';
           break;
+        case t_base_type::TYPE_UUID:
+          out << indent() << "$output .= hex2bin(str_replace('-', '', $" << name << "));" << '\n';
+          break;
         default:
           throw "compiler error: no PHP name for base type " + t_base_type::t_base_name(tbase);
         }
@@ -2453,6 +2471,9 @@ void t_php_generator::generate_serialize_field(ostream& out, t_field* tfield, st
           break;
         case t_base_type::TYPE_DOUBLE:
           out << "writeDouble($" << name << ");";
+          break;
+        case t_base_type::TYPE_UUID:
+          out << "writeUuid($" << name << ");";
           break;
         default:
           throw "compiler error: no PHP name for base type " + t_base_type::t_base_name(tbase);
@@ -2782,6 +2803,8 @@ string t_php_generator::type_to_cast(t_type* type) {
       return "(double)";
     case t_base_type::TYPE_STRING:
       return "(string)";
+    case t_base_type::TYPE_UUID:
+      return "(string)";
     default:
       return "";
     }
@@ -2816,6 +2839,8 @@ string t_php_generator::type_to_enum(t_type* type) {
       return "TType::I64";
     case t_base_type::TYPE_DOUBLE:
       return "TType::DOUBLE";
+    case t_base_type::TYPE_UUID:
+      return "TType::UUID";
     default:
       throw "compiler error: unhandled type";
     }
@@ -2859,6 +2884,8 @@ string t_php_generator::type_to_phpdoc(t_type* type) {
       return "int";
     case t_base_type::TYPE_DOUBLE:
       return "double";
+    case t_base_type::TYPE_UUID:
+      return "string";
     default:
       throw "compiler error: unhandled type";
     }

--- a/lib/php/lib/Base/TBase.php
+++ b/lib/php/lib/Base/TBase.php
@@ -41,7 +41,8 @@ abstract class TBase
         TType::I32 => 'I32',
         TType::I64 => 'I64',
         TType::DOUBLE => 'Double',
-        TType::STRING => 'String'
+        TType::STRING => 'String',
+        TType::UUID => 'Uuid'
     );
 
     abstract public function read($input);

--- a/lib/php/lib/Protocol/TBinaryProtocol.php
+++ b/lib/php/lib/Protocol/TBinaryProtocol.php
@@ -222,6 +222,7 @@ class TBinaryProtocol extends TProtocol
 
     public function writeUuid($uuid)
     {
+        self::validateUuid($uuid);
         $data = hex2bin(str_replace('-', '', $uuid));
         $this->trans_->write($data, 16);
 

--- a/lib/php/lib/Protocol/TBinaryProtocol.php
+++ b/lib/php/lib/Protocol/TBinaryProtocol.php
@@ -220,6 +220,14 @@ class TBinaryProtocol extends TProtocol
         return $result + $len;
     }
 
+    public function writeUuid($uuid)
+    {
+        $data = hex2bin(str_replace('-', '', $uuid));
+        $this->trans_->write($data, 16);
+
+        return 16;
+    }
+
     public function readMessageBegin(&$name, &$type, &$seqid)
     {
         $result = $this->readI32($sz);
@@ -449,5 +457,18 @@ class TBinaryProtocol extends TProtocol
         }
 
         return $result + $len;
+    }
+
+    public function readUuid(&$value)
+    {
+        $data = $this->trans_->readAll(16);
+        $hex = bin2hex($data);
+        $value = substr($hex, 0, 8) . '-' .
+                 substr($hex, 8, 4) . '-' .
+                 substr($hex, 12, 4) . '-' .
+                 substr($hex, 16, 4) . '-' .
+                 substr($hex, 20, 12);
+
+        return 16;
     }
 }

--- a/lib/php/lib/Protocol/TCompactProtocol.php
+++ b/lib/php/lib/Protocol/TCompactProtocol.php
@@ -45,6 +45,7 @@ class TCompactProtocol extends TProtocol
     const COMPACT_SET = 0x0A;
     const COMPACT_MAP = 0x0B;
     const COMPACT_STRUCT = 0x0C;
+    const COMPACT_UUID = 0x0D;
 
     const STATE_CLEAR = 0;
     const STATE_FIELD_WRITE = 1;
@@ -76,6 +77,7 @@ class TCompactProtocol extends TProtocol
         TType::LST => TCompactProtocol::COMPACT_LIST,
         TType::SET => TCompactProtocol::COMPACT_SET,
         TType::MAP => TCompactProtocol::COMPACT_MAP,
+        TType::UUID => TCompactProtocol::COMPACT_UUID,
     );
 
     protected static $ttypes = array(
@@ -92,6 +94,7 @@ class TCompactProtocol extends TProtocol
         TCompactProtocol::COMPACT_LIST => TType::LST,
         TCompactProtocol::COMPACT_SET => TType::SET,
         TCompactProtocol::COMPACT_MAP => TType::MAP,
+        TCompactProtocol::COMPACT_UUID => TType::UUID,
     );
 
     protected $state = TCompactProtocol::STATE_CLEAR;
@@ -370,6 +373,14 @@ class TCompactProtocol extends TProtocol
         return $result + $len;
     }
 
+    public function writeUuid($uuid)
+    {
+        $data = hex2bin(str_replace('-', '', $uuid));
+        $this->trans_->write($data, 16);
+
+        return 16;
+    }
+
     public function readFieldBegin(&$name, &$field_type, &$field_id)
     {
         $result = $this->readUByte($compact_type_and_delta);
@@ -585,6 +596,19 @@ class TCompactProtocol extends TProtocol
         }
 
         return $result + $len;
+    }
+
+    public function readUuid(&$value)
+    {
+        $data = $this->trans_->readAll(16);
+        $hex = bin2hex($data);
+        $value = substr($hex, 0, 8) . '-' .
+                 substr($hex, 8, 4) . '-' .
+                 substr($hex, 12, 4) . '-' .
+                 substr($hex, 16, 4) . '-' .
+                 substr($hex, 20, 12);
+
+        return 16;
     }
 
     public function getTType($byte)

--- a/lib/php/lib/Protocol/TCompactProtocol.php
+++ b/lib/php/lib/Protocol/TCompactProtocol.php
@@ -375,6 +375,7 @@ class TCompactProtocol extends TProtocol
 
     public function writeUuid($uuid)
     {
+        self::validateUuid($uuid);
         $data = hex2bin(str_replace('-', '', $uuid));
         $this->trans_->write($data, 16);
 

--- a/lib/php/lib/Protocol/TJSONProtocol.php
+++ b/lib/php/lib/Protocol/TJSONProtocol.php
@@ -582,6 +582,7 @@ class TJSONProtocol extends TProtocol
 
     public function writeUuid($uuid)
     {
+        self::validateUuid($uuid);
         $this->writeJSONString($uuid);
     }
 
@@ -745,6 +746,7 @@ class TJSONProtocol extends TProtocol
     public function readUuid(&$uuid)
     {
         $uuid = $this->readJSONString(false);
+        self::validateUuid($uuid);
 
         return true;
     }

--- a/lib/php/lib/Protocol/TJSONProtocol.php
+++ b/lib/php/lib/Protocol/TJSONProtocol.php
@@ -74,6 +74,7 @@ class TJSONProtocol extends TProtocol
     const NAME_MAP = "map";
     const NAME_LIST = "lst";
     const NAME_SET = "set";
+    const NAME_UUID = "uid";
 
     private function getTypeNameForTypeID($typeID)
     {
@@ -100,6 +101,8 @@ class TJSONProtocol extends TProtocol
                 return self::NAME_SET;
             case TType::LST:
                 return self::NAME_LIST;
+            case TType::UUID:
+                return self::NAME_UUID;
             default:
                 throw new TProtocolException("Unrecognized type", TProtocolException::UNKNOWN);
         }
@@ -148,6 +151,9 @@ class TJSONProtocol extends TProtocol
                     break;
                 case 't':
                     $result = TType::BOOL;
+                    break;
+                case 'u':
+                    $result = TType::UUID;
                     break;
             }
         }
@@ -574,6 +580,11 @@ class TJSONProtocol extends TProtocol
         $this->writeJSONString($str);
     }
 
+    public function writeUuid($uuid)
+    {
+        $this->writeJSONString($uuid);
+    }
+
     /**
      * Reads the message header
      *
@@ -727,6 +738,13 @@ class TJSONProtocol extends TProtocol
     public function readString(&$str)
     {
         $str = $this->readJSONString(false);
+
+        return true;
+    }
+
+    public function readUuid(&$uuid)
+    {
+        $uuid = $this->readJSONString(false);
 
         return true;
     }

--- a/lib/php/lib/Protocol/TProtocol.php
+++ b/lib/php/lib/Protocol/TProtocol.php
@@ -131,6 +131,13 @@ abstract class TProtocol
 
     abstract public function writeUuid($uuid);
 
+    protected static function validateUuid($uuid)
+    {
+        if (!is_string($uuid) || !preg_match('/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/', $uuid)) {
+            throw new TProtocolException('Invalid UUID format', TProtocolException::INVALID_DATA);
+        }
+    }
+
     /**
      * Reads the message header
      *

--- a/lib/php/lib/Protocol/TProtocol.php
+++ b/lib/php/lib/Protocol/TProtocol.php
@@ -129,6 +129,8 @@ abstract class TProtocol
 
     abstract public function writeString($str);
 
+    abstract public function writeUuid($uuid);
+
     /**
      * Reads the message header
      *
@@ -177,6 +179,8 @@ abstract class TProtocol
 
     abstract public function readString(&$str);
 
+    abstract public function readUuid(&$uuid);
+
     /**
      * The skip function is a utility to parse over unrecognized date without
      * causing corruption.
@@ -200,6 +204,8 @@ abstract class TProtocol
                 return $this->readDouble($dub);
             case TType::STRING:
                 return $this->readString($str);
+            case TType::UUID:
+                return $this->readUuid($uuid);
             case TType::STRUCT:
                 $result = $this->readStructBegin($name);
                 while (true) {
@@ -271,6 +277,8 @@ abstract class TProtocol
                 return $itrans->readAll(8);
             case TType::DOUBLE:
                 return $itrans->readAll(8);
+            case TType::UUID:
+                return $itrans->readAll(16);
             case TType::STRING:
                 $len = unpack('N', $itrans->readAll(4));
                 $len = $len[1];

--- a/lib/php/lib/Protocol/TProtocolDecorator.php
+++ b/lib/php/lib/Protocol/TProtocolDecorator.php
@@ -178,6 +178,11 @@ abstract class TProtocolDecorator extends TProtocol
         return $this->concreteProtocol_->writeString($str);
     }
 
+    public function writeUuid($uuid)
+    {
+        return $this->concreteProtocol_->writeUuid($uuid);
+    }
+
     /**
      * Reads the message header
      *
@@ -281,5 +286,10 @@ abstract class TProtocolDecorator extends TProtocol
     public function readString(&$str)
     {
         return $this->concreteProtocol_->readString($str);
+    }
+
+    public function readUuid(&$uuid)
+    {
+        return $this->concreteProtocol_->readUuid($uuid);
     }
 }

--- a/lib/php/lib/Protocol/TSimpleJSONProtocol.php
+++ b/lib/php/lib/Protocol/TSimpleJSONProtocol.php
@@ -270,6 +270,11 @@ class TSimpleJSONProtocol extends TProtocol
         $this->writeJSONString($str);
     }
 
+    public function writeUuid($uuid)
+    {
+        $this->writeJSONString($uuid);
+    }
+
     /**
      * Reading methods.
      *
@@ -369,6 +374,11 @@ class TSimpleJSONProtocol extends TProtocol
     }
 
     public function readString(&$str)
+    {
+        throw new TException("Not implemented");
+    }
+
+    public function readUuid(&$uuid)
     {
         throw new TException("Not implemented");
     }

--- a/lib/php/lib/Type/TType.php
+++ b/lib/php/lib/Type/TType.php
@@ -42,6 +42,7 @@ class TType
     const MAP    = 13;
     const SET    = 14;
     const LST    = 15;    // N.B. cannot use LIST keyword in PHP!
+    const UUID   = 16;
     const UTF8   = 16;
     const UTF16  = 17;
 }

--- a/lib/php/test/Resources/ThriftTest.thrift
+++ b/lib/php/test/Resources/ThriftTest.thrift
@@ -19,7 +19,7 @@
 
 namespace php TestValidators
 
-include "../../../../test/v0.16/ThriftTest.thrift"
+include "../../../../test/ThriftTest.thrift"
 
 union UnionOfStrings {
   1: string aa;

--- a/lib/php/test/Unit/Lib/Protocol/TBinaryProtocolTest.php
+++ b/lib/php/test/Unit/Lib/Protocol/TBinaryProtocolTest.php
@@ -413,6 +413,36 @@ class TBinaryProtocolTest extends TestCase
         $this->assertEquals(10, $protocol->writeString($value));
     }
 
+    public function testWriteUuid()
+    {
+        $uuid = '01234567-89ab-cdef-0123-456789abcdef';
+        $transport = $this->createMock(TTransport::class);
+        $protocol = new TBinaryProtocol($transport, false, false);
+
+        $transport
+            ->expects($this->once())
+            ->method('write')
+            ->with(hex2bin('0123456789abcdef0123456789abcdef'), 16)
+            ->willReturn(16);
+
+        $this->assertEquals(16, $protocol->writeUuid($uuid));
+    }
+
+    public function testReadUuid()
+    {
+        $transport = $this->createMock(TTransport::class);
+        $protocol = new TBinaryProtocol($transport, false, false);
+
+        $transport
+            ->expects($this->once())
+            ->method('readAll')
+            ->with(16)
+            ->willReturn(hex2bin('0123456789abcdef0123456789abcdef'));
+
+        $this->assertEquals(16, $protocol->readUuid($value));
+        $this->assertEquals('01234567-89ab-cdef-0123-456789abcdef', $value);
+    }
+
     /**
      * @dataProvider readMessageBeginDataProvider
      */

--- a/lib/php/test/Unit/Lib/Protocol/TBinaryProtocolTest.php
+++ b/lib/php/test/Unit/Lib/Protocol/TBinaryProtocolTest.php
@@ -444,6 +444,30 @@ class TBinaryProtocolTest extends TestCase
     }
 
     /**
+     * @dataProvider invalidUuidDataProvider
+     */
+    public function testWriteUuidValidation($invalidUuid)
+    {
+        $transport = $this->createMock(TTransport::class);
+        $protocol = new TBinaryProtocol($transport, false, false);
+
+        $this->expectException(\Thrift\Exception\TProtocolException::class);
+        $this->expectExceptionMessage('Invalid UUID format');
+        $protocol->writeUuid($invalidUuid);
+    }
+
+    public function invalidUuidDataProvider()
+    {
+        return [
+            'too short' => ['550e8400-e29b-41d4-a716'],
+            'no dashes' => ['550e8400e29b41d4a716446655440000'],
+            'invalid char' => ['550e8400-e29b-41d4-a716-44665544000g'],
+            'empty' => [''],
+            'not a string' => [12345],
+        ];
+    }
+
+    /**
      * @dataProvider readMessageBeginDataProvider
      */
     public function testReadMessageBegin(

--- a/lib/php/test/Unit/Lib/Protocol/TCompactProtocolTest.php
+++ b/lib/php/test/Unit/Lib/Protocol/TCompactProtocolTest.php
@@ -825,6 +825,30 @@ class TCompactProtocolTest extends TestCase
     }
 
     /**
+     * @dataProvider invalidUuidDataProvider
+     */
+    public function testWriteUuidValidation($invalidUuid)
+    {
+        $transport = $this->createMock(TTransport::class);
+        $protocol = new TCompactProtocol($transport);
+
+        $this->expectException(\Thrift\Exception\TProtocolException::class);
+        $this->expectExceptionMessage('Invalid UUID format');
+        $protocol->writeUuid($invalidUuid);
+    }
+
+    public function invalidUuidDataProvider()
+    {
+        return [
+            'too short' => ['550e8400-e29b-41d4-a716'],
+            'no dashes' => ['550e8400e29b41d4a716446655440000'],
+            'invalid char' => ['550e8400-e29b-41d4-a716-44665544000g'],
+            'empty' => [''],
+            'not a string' => [12345],
+        ];
+    }
+
+    /**
      * @dataProvider writeI64DataProvider
      */
     public function testWriteI64(

--- a/lib/php/test/Unit/Lib/Protocol/TCompactProtocolTest.php
+++ b/lib/php/test/Unit/Lib/Protocol/TCompactProtocolTest.php
@@ -794,6 +794,36 @@ class TCompactProtocolTest extends TestCase
         $this->assertSame(5, $protocol->writeString('test'));
     }
 
+    public function testWriteUuid()
+    {
+        $uuid = '01234567-89ab-cdef-0123-456789abcdef';
+        $transport = $this->createMock(TTransport::class);
+        $protocol = new TCompactProtocol($transport);
+
+        $transport
+            ->expects($this->once())
+            ->method('write')
+            ->with(hex2bin('0123456789abcdef0123456789abcdef'), 16)
+            ->willReturn(16);
+
+        $this->assertSame(16, $protocol->writeUuid($uuid));
+    }
+
+    public function testReadUuid()
+    {
+        $transport = $this->createMock(TTransport::class);
+        $protocol = new TCompactProtocol($transport);
+
+        $transport
+            ->expects($this->once())
+            ->method('readAll')
+            ->with(16)
+            ->willReturn(hex2bin('0123456789abcdef0123456789abcdef'));
+
+        $this->assertSame(16, $protocol->readUuid($value));
+        $this->assertSame('01234567-89ab-cdef-0123-456789abcdef', $value);
+    }
+
     /**
      * @dataProvider writeI64DataProvider
      */

--- a/test/php/Handler.php
+++ b/test/php/Handler.php
@@ -42,6 +42,11 @@ class Handler implements \ThriftTest\ThriftTestIf
         return $thing;
     }
 
+    public function testUuid($thing)
+    {
+        return $thing;
+    }
+
     public function testStruct(\ThriftTest\Xtruct $thing)
     {
         return $thing;

--- a/test/php/Makefile.am
+++ b/test/php/Makefile.am
@@ -17,11 +17,11 @@
 # under the License.
 #
 
-stubs: ../v0.16/ThriftTest.thrift
-	$(THRIFT) --gen php ../v0.16/ThriftTest.thrift
-	$(THRIFT) --gen php:inlined ../v0.16/ThriftTest.thrift
+stubs: ../ThriftTest.thrift
+	$(THRIFT) --gen php ../ThriftTest.thrift
+	$(THRIFT) --gen php:inlined ../ThriftTest.thrift
 	$(MKDIR_P) gen-php-classmap
-	$(THRIFT) -out gen-php-classmap --gen php:classmap ../v0.16/ThriftTest.thrift
+	$(THRIFT) -out gen-php-classmap --gen php:classmap ../ThriftTest.thrift
 
 php_ext_dir:
 	mkdir -p php_ext_dir

--- a/test/php/TestClient.php
+++ b/test/php/TestClient.php
@@ -189,6 +189,21 @@ roundtrip($testClient, 'testDouble', -852.234234234);
  */
 
 /**
+ * UUID TEST
+ */
+print_r("testUuid('00000000-0000-0000-0000-000000000000')");
+$uuid_in = '00000000-0000-0000-0000-000000000000';
+$uuid_out = $testClient->testUuid($uuid_in);
+print_r(" = \"$uuid_out\"\n");
+if ($uuid_in !== $uuid_out) {
+    echo "**FAILED**\n";
+    $exitcode |= ERR_BASETYPES;
+}
+
+roundtrip($testClient, 'testUuid', '00000000-0000-0000-0000-000000000000');
+roundtrip($testClient, 'testUuid', '550e8400-e29b-41d4-a716-446655440000');
+
+/**
  * STRUCT TEST
  */
 print_r("testStruct({\"Zero\", 1, -3, -5})");


### PR DESCRIPTION
## Summary

- Implement UUID as a first-class type in the PHP library and code generator
- UUID (wire type 16, compact protocol 0x0D) represented as canonical string `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`
- Fixed 16 bytes on wire (binary/compact), JSON string `"uid"` type name in JSON protocol
- Add `TYPE_UUID` handling in all code generation switch statements in `t_php_generator.cc`
- Update PHP test configs to use current `ThriftTest.thrift` with UUID fields

## Files changed (13)

**PHP Library (8 files):**
- `TType.php` — `UUID = 16` constant
- `TProtocol.php` — abstract methods + skip support
- `TBinaryProtocol.php` — read/write 16 raw bytes
- `TCompactProtocol.php` — `COMPACT_UUID = 0x0D` + type mappings + read/write
- `TJSONProtocol.php` — `NAME_UUID = "uid"` + type mappings + read/write as string
- `TSimpleJSONProtocol.php` — write support (read-only protocol)
- `TProtocolDecorator.php` — delegation
- `TBase.php` — `$tmethod` dispatch

**Code generator (1 file):**
- `t_php_generator.cc` — UUID in all 8 switch statements

**Tests & config (4 files):**
- Unit tests for `TBinaryProtocol` and `TCompactProtocol`
- Updated `ThriftTest.thrift` references from `v0.16` to current

## Test plan

- [x] UUID unit tests pass for TBinaryProtocol (write + read roundtrip)
- [x] UUID unit tests pass for TCompactProtocol (write + read roundtrip)
- [x] Full PHP unit test suite passes (399/400, 1 pre-existing failure in TSocketPoolTest)
- [ ] Build thrift compiler and verify PHP code generation with `test/ThriftTest.thrift`
- [ ] Cross-language compatibility verification