### PR TITLE
build: bootstrap configured THRIFT for PHP stubs

### DIFF
--- a/lib/php/test/Makefile.am
+++ b/lib/php/test/Makefile.am
@@ -18,21 +18,24 @@
 #
 
 PHPUNIT=php $(top_srcdir)/vendor/bin/phpunit
-PHP_THRIFT_COMPILER=$(top_builddir)/compiler/cpp/thrift
 
-stubs: $(PHP_THRIFT_COMPILER) Resources/ThriftTest.thrift
+$(THRIFT):
+	$(MAKE) -C $(top_builddir)/compiler/cpp/src thrift/libparse.a
+	$(MAKE) -C $(top_builddir)/compiler/cpp thrift
+
+stubs: $(THRIFT) Resources/ThriftTest.thrift
 	mkdir -p ./Resources/packages/php
 	mkdir -p ./Resources/packages/phpi
 	mkdir -p ./Resources/packages/phpv
 	mkdir -p ./Resources/packages/phpvo
 	mkdir -p ./Resources/packages/phpjs
 	mkdir -p ./Resources/packages/phpcm
-	$(PHP_THRIFT_COMPILER) --gen php:nsglobal="Basic" -r --out ./Resources/packages/php Resources/ThriftTest.thrift
-	$(PHP_THRIFT_COMPILER) --gen php:inlined,nsglobal="BasicInline" -r --out ./Resources/packages/phpi Resources/ThriftTest.thrift
-	$(PHP_THRIFT_COMPILER) --gen php:validate,nsglobal="Validate" -r --out ./Resources/packages/phpv Resources/ThriftTest.thrift
-	$(PHP_THRIFT_COMPILER) --gen php:validate,oop,nsglobal="ValidateOop" -r --out ./Resources/packages/phpvo Resources/ThriftTest.thrift
-	$(PHP_THRIFT_COMPILER) --gen php:json,nsglobal="Json" -r --out ./Resources/packages/phpjs Resources/ThriftTest.thrift
-	$(PHP_THRIFT_COMPILER) --gen php:classmap,server,rest,nsglobal="Classmap" -r --out ./Resources/packages/phpcm Resources/ThriftTest.thrift
+	$(THRIFT) --gen php:nsglobal="Basic" -r --out ./Resources/packages/php Resources/ThriftTest.thrift
+	$(THRIFT) --gen php:inlined,nsglobal="BasicInline" -r --out ./Resources/packages/phpi Resources/ThriftTest.thrift
+	$(THRIFT) --gen php:validate,nsglobal="Validate" -r --out ./Resources/packages/phpv Resources/ThriftTest.thrift
+	$(THRIFT) --gen php:validate,oop,nsglobal="ValidateOop" -r --out ./Resources/packages/phpvo Resources/ThriftTest.thrift
+	$(THRIFT) --gen php:json,nsglobal="Json" -r --out ./Resources/packages/phpjs Resources/ThriftTest.thrift
+	$(THRIFT) --gen php:classmap,server,rest,nsglobal="Classmap" -r --out ./Resources/packages/phpcm Resources/ThriftTest.thrift
 
 deps: $(top_srcdir)/composer.json
 	composer install --working-dir=$(top_srcdir)

--- a/lib/php/test/Makefile.am
+++ b/lib/php/test/Makefile.am
@@ -18,20 +18,21 @@
 #
 
 PHPUNIT=php $(top_srcdir)/vendor/bin/phpunit
+PHP_THRIFT_COMPILER=$(top_builddir)/compiler/cpp/thrift
 
-stubs: Resources/ThriftTest.thrift
+stubs: $(PHP_THRIFT_COMPILER) Resources/ThriftTest.thrift
 	mkdir -p ./Resources/packages/php
 	mkdir -p ./Resources/packages/phpi
 	mkdir -p ./Resources/packages/phpv
 	mkdir -p ./Resources/packages/phpvo
 	mkdir -p ./Resources/packages/phpjs
 	mkdir -p ./Resources/packages/phpcm
-	$(THRIFT) --gen php:nsglobal="Basic" -r --out ./Resources/packages/php Resources/ThriftTest.thrift
-	$(THRIFT) --gen php:inlined,nsglobal="BasicInline" -r --out ./Resources/packages/phpi Resources/ThriftTest.thrift
-	$(THRIFT) --gen php:validate,nsglobal="Validate" -r --out ./Resources/packages/phpv Resources/ThriftTest.thrift
-	$(THRIFT) --gen php:validate,oop,nsglobal="ValidateOop" -r --out ./Resources/packages/phpvo Resources/ThriftTest.thrift
-	$(THRIFT) --gen php:json,nsglobal="Json" -r --out ./Resources/packages/phpjs Resources/ThriftTest.thrift
-	$(THRIFT) --gen php:classmap,server,rest,nsglobal="Classmap" -r --out ./Resources/packages/phpcm Resources/ThriftTest.thrift
+	$(PHP_THRIFT_COMPILER) --gen php:nsglobal="Basic" -r --out ./Resources/packages/php Resources/ThriftTest.thrift
+	$(PHP_THRIFT_COMPILER) --gen php:inlined,nsglobal="BasicInline" -r --out ./Resources/packages/phpi Resources/ThriftTest.thrift
+	$(PHP_THRIFT_COMPILER) --gen php:validate,nsglobal="Validate" -r --out ./Resources/packages/phpv Resources/ThriftTest.thrift
+	$(PHP_THRIFT_COMPILER) --gen php:validate,oop,nsglobal="ValidateOop" -r --out ./Resources/packages/phpvo Resources/ThriftTest.thrift
+	$(PHP_THRIFT_COMPILER) --gen php:json,nsglobal="Json" -r --out ./Resources/packages/phpjs Resources/ThriftTest.thrift
+	$(PHP_THRIFT_COMPILER) --gen php:classmap,server,rest,nsglobal="Classmap" -r --out ./Resources/packages/phpcm Resources/ThriftTest.thrift
 
 deps: $(top_srcdir)/composer.json
 	composer install --working-dir=$(top_srcdir)

--- a/test/php/Makefile.am
+++ b/test/php/Makefile.am
@@ -17,13 +17,15 @@
 # under the License.
 #
 
-PHP_THRIFT_COMPILER=$(top_builddir)/compiler/cpp/thrift
+$(THRIFT):
+	$(MAKE) -C $(top_builddir)/compiler/cpp/src thrift/libparse.a
+	$(MAKE) -C $(top_builddir)/compiler/cpp thrift
 
-stubs: $(PHP_THRIFT_COMPILER) ../ThriftTest.thrift
-	$(PHP_THRIFT_COMPILER) --gen php ../ThriftTest.thrift
-	$(PHP_THRIFT_COMPILER) --gen php:inlined ../ThriftTest.thrift
+stubs: $(THRIFT) ../ThriftTest.thrift
+	$(THRIFT) --gen php ../ThriftTest.thrift
+	$(THRIFT) --gen php:inlined ../ThriftTest.thrift
 	$(MKDIR_P) gen-php-classmap
-	$(PHP_THRIFT_COMPILER) -out gen-php-classmap --gen php:classmap,server,rest ../ThriftTest.thrift
+	$(THRIFT) -out gen-php-classmap --gen php:classmap,server,rest ../ThriftTest.thrift
 
 php_ext_dir:
 	mkdir -p php_ext_dir

--- a/test/php/Makefile.am
+++ b/test/php/Makefile.am
@@ -17,11 +17,13 @@
 # under the License.
 #
 
-stubs: ../ThriftTest.thrift
-	$(THRIFT) --gen php ../ThriftTest.thrift
-	$(THRIFT) --gen php:inlined ../ThriftTest.thrift
+PHP_THRIFT_COMPILER=$(top_builddir)/compiler/cpp/thrift
+
+stubs: $(PHP_THRIFT_COMPILER) ../ThriftTest.thrift
+	$(PHP_THRIFT_COMPILER) --gen php ../ThriftTest.thrift
+	$(PHP_THRIFT_COMPILER) --gen php:inlined ../ThriftTest.thrift
 	$(MKDIR_P) gen-php-classmap
-	$(THRIFT) -out gen-php-classmap --gen php:classmap,server,rest ../ThriftTest.thrift
+	$(PHP_THRIFT_COMPILER) -out gen-php-classmap --gen php:classmap,server,rest ../ThriftTest.thrift
 
 php_ext_dir:
 	mkdir -p php_ext_dir


### PR DESCRIPTION
## Summary
- keep PHP test stub generation on the configured `$(THRIFT)` executable instead of hardcoding a PHP-only compiler path
- add a make rule that bootstraps the configured thrift binary from the local build tree when the default in-tree compiler is used
- make `lib/php/test` and `test/php` regenerate their fixtures after `compiler/cpp clean` without a separate manual compiler build step

## Verification
- `docker pull thrift/thrift-build:ubuntu-focal`
- `docker run --rm -u root -e HOME=/root -v "$PWD":/thrift/src -w /thrift/src thrift/thrift-build:ubuntu-focal bash -lc "make -C compiler/cpp clean && make -C lib/php/test clean stubs && make -C compiler/cpp clean && make -C test/php clean stubs"`

Generated-by: Codex GPT-5